### PR TITLE
Fixed display error message when going from one error to another.

### DIFF
--- a/custom/gnap-angular/js/develop/gnap/validation-messages.directive.js
+++ b/custom/gnap-angular/js/develop/gnap/validation-messages.directive.js
@@ -83,8 +83,8 @@
                 }
             });
 
-            $scope.$watch(function () {
-                return form[watchAttr].$invalid;
+            $scope.$watchCollection(function () {
+                return form[watchAttr].$error;
             }, function () {
                 if (form[watchAttr].$dirty) {
                     ctrl.renderMessages(form[watchAttr].$error, multiple);


### PR DESCRIPTION
Example to reproduce old bug:
Add `required` and `ng-pattern` to a field and create 2 error messages.
When field is empty required message is shown, if you then type an invalid character according to the pattern, the required message still is shown.