### PR TITLE
Bug fix for validation of controls inside a ng-form

### DIFF
--- a/custom/gnap-angular/app/main/main.controller.js
+++ b/custom/gnap-angular/app/main/main.controller.js
@@ -14,8 +14,8 @@
         vm.search = function() {
             $window.alert('Searching for ' + vm.keywords);
         };
-		
-		vm.scrollToTop = function() {            
+
+        vm.scrollToTop = function() {            
             $location.hash('main-container');
             $anchorScroll();
         };

--- a/custom/gnap-angular/app/main/main.controller.js
+++ b/custom/gnap-angular/app/main/main.controller.js
@@ -5,14 +5,19 @@
         .module('gnap-example-app')
         .controller('MainController', MainController);
 
-    MainController.$inject = ['$window'];
+    MainController.$inject = ['$window', '$location', '$anchorScroll'];
 
-    function MainController($window) {
+    function MainController($window, $location, $anchorScroll) {
         /* jshint validthis: true */
         var vm = this;
 
         vm.search = function() {
             $window.alert('Searching for ' + vm.keywords);
+        };
+		
+		vm.scrollToTop = function() {            
+            $location.hash('main-container');
+            $anchorScroll();
         };
     }
 })();

--- a/custom/gnap-angular/app/main/main.html
+++ b/custom/gnap-angular/app/main/main.html
@@ -37,7 +37,7 @@
         </div>
     </div>
 
-    <a href="#" id="btn-scroll-up" class="btn-scroll-up btn btn-sm btn-inverse">
+    <a href="" data-ng-click="main.scrollToTop()" id="btn-scroll-up" class="btn-scroll-up btn btn-sm btn-inverse">
         <i class="icon-double-angle-up icon-only bigger-110"></i>
     </a>
 </div>

--- a/custom/gnap-angular/js/develop/gnap/sidebar.service.js
+++ b/custom/gnap-angular/js/develop/gnap/sidebar.service.js
@@ -134,7 +134,7 @@
         function setSelected(path) {
             // parse the path into an array
             /* jshint laxbreak:true */
-            var parsedPath = path == null
+            var parsedPath = path === null
                                 ? []
                                 : ((path instanceof Array)
                                     ? path

--- a/custom/gnap-angular/js/develop/gnap/validation-messages.directive.js
+++ b/custom/gnap-angular/js/develop/gnap/validation-messages.directive.js
@@ -83,8 +83,8 @@
                 }
             });
 
-            $scope.$watch(function () {
-                return form[watchAttr].$invalid;
+            $scope.$watchCollection(function () {
+                return form[watchAttr].$error;
             }, function () {
                 if (form[watchAttr].$dirty) {
                     ctrl.renderMessages(form[watchAttr].$error, multiple);

--- a/custom/gnap-angular/js/develop/gnap/validation-messages.directive.js
+++ b/custom/gnap-angular/js/develop/gnap/validation-messages.directive.js
@@ -68,15 +68,29 @@
         function link($scope, element, $attrs, ctrls) {
             var form = ctrls[0];
             var ctrl = ctrls[1];
-            
+
             //JavaScript treats empty strings as false, but ng-message-multiple by itself is an empty string
             var multiple = angular.isString($attrs.gnapValidationMessagesMultiple) ||
                            angular.isString($attrs.multiple);
 
             var watchAttr = $attrs.gnapValidationMessages || $attrs['for']; //for is a reserved keyword
 
+            //Get the form controller from the validation-messages
+            var elementParent = element.parent();
+            var parentFormController = elementParent.controller('form');
+            var lastFormController = parentFormController;
+
+            // Get the parent form of the form
+            while(elementParent != null && lastFormController != null) {
+                elementParent = elementParent.parent();
+                lastFormController = elementParent.controller('form');
+                if(lastFormController != null) {
+                  parentFormController = lastFormController;
+                }
+            }
+
             $scope.$watch(function () {
-                return form.$submitted;
+                return parentFormController.$submitted;
             }, function (submitted) {
                 if (submitted) {
                     ctrl.renderMessages(form[watchAttr].$error, multiple);


### PR DESCRIPTION
When validation was needed of controls inside a ng-form the form submit did not trigger the validation messages.

Also fixed timepicker when initial date is null or undefined.