### PR TITLE
Allow custom content to be transcluded at bottom of sidebar

### DIFF
--- a/custom/gnap-angular/js/develop/gnap/sidebar.directive.js
+++ b/custom/gnap-angular/js/develop/gnap/sidebar.directive.js
@@ -24,7 +24,8 @@
             restrict: 'A',
             replace: true,
             templateUrl: 'template/gnap/sidebar/sidebar.html',
-            link: link
+            link: link,
+            transclude: true
         };
 
         function link(scope) {
@@ -139,6 +140,7 @@
             "    <div class=\"sidebar-collapse\" id=\"sidebar-collapse\" ng-click=\"toggleCollapsed()\">\n" +
             "        <i ng-class=\"{\'icon-double-angle-left\': !settings.collapsed, \'icon-double-angle-right\': settings.collapsed}\"><\/i>\n" +
             "    <\/div>\n" +
+            "    <div ng-transclude><\/div>\n" +
             "<\/div>\n" +
             "");
         /* jshint ignore:end */


### PR DESCRIPTION
Example usage:

        <div gnap-sidebar>
            <img ng-repeat="layer in mainVm.layers | filter: mainVm.poiToggledOn"
                 ng-src="'../../{{layer.iconUrl}}"
                 ng-class="{ 'translucent': mainVm.poiVisible(layer) }"
                 title="{{(layer.translationId || 'main.common.' + layer.itemType + 's') | translate}}"
                 class="menu-img" />
        </div>