### PR TITLE
directive name was wrong in example

### DIFF
--- a/custom/gnap-angular/app/main/examples/form-controls/date-range-picker.html
+++ b/custom/gnap-angular/app/main/examples/form-controls/date-range-picker.html
@@ -3,7 +3,7 @@
 <pre><code gnap-highlight>&lt;div class=&quot;form-group&quot; ng-controller=&quot;gnap-date-range-picker as vm&quot;&gt;
     &lt;label class=&quot;col-sm-3 control-label no-padding-right&quot;&gt;Date Range&lt;/label&gt;
     &lt;div class=&quot;col-sm-9&quot;&gt;
-        &lt;span gnap-date-range date-begin=&quot;vm.range.dateStart&quot; date-end=&quot;vm.range.dateEnd&quot; icon-position=&quot;&#123;&#123;vm.iconPosition&#125;&#125;&quot;&gt;&lt;/span&gt;
+        &lt;span gnap-daterange date-begin=&quot;vm.range.dateStart&quot; date-end=&quot;vm.range.dateEnd&quot; icon-position=&quot;&#123;&#123;vm.iconPosition&#125;&#125;&quot;&gt;&lt;/span&gt;
     &lt;/div&gt;
 &lt;/div&gt;</code></pre>
   </div>


### PR DESCRIPTION
There was a typo in the examples page. It had a '-' sign too many.