### PR TITLE
Slide up sidebar when item clicked

### DIFF
--- a/custom/gnap-angular/js/develop/gnap/sidebar.directive.js
+++ b/custom/gnap-angular/js/develop/gnap/sidebar.directive.js
@@ -36,9 +36,9 @@
                 if (item.items) {
                     sidebarService.toggleSubmenu(item);
                 }
-
-                if (item.click) {
-                    item.click();
+                else{
+                    // slide up menu when navigationable page is clicked
+                    sidebarService.toggleMenu();
                 }
 
                 if (item.state) {


### PR DESCRIPTION
..when a navigational menu-item (not an item with sub-items) is clicked. Previously the menu stayed open when navigated to a new page. Now it should automatically close.
